### PR TITLE
Adding curl demo for bash users

### DIFF
--- a/examples/graphql/balance_query.gql
+++ b/examples/graphql/balance_query.gql
@@ -1,0 +1,8 @@
+{
+  "query": "{
+    users(first: 5, where: { balance_gt: 0 }) {
+      id
+      balance
+    }
+  }"
+}

--- a/presentation/deck.mdx
+++ b/presentation/deck.mdx
@@ -52,6 +52,17 @@ const result = await axios.post(QUERY_URL, { query })
 
 ---
 
+# 📡 Graph Query
+
+- From your command line
+
+```bash
+$ QUERY_URL='https://api.thegraph.com/subgraphs/name/dan13ram/fdai-token'
+$ curl -X POST -d "@examples/graphql/balance_query.gql" $QUERY_URL | json_pp 
+```
+
+---
+
 # 📡 Graph Query - Example  
 
 <GraphQuery/>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1128312/124239910-7a27e680-db1a-11eb-9dff-6fd3d115040b.png)

Before I tried to jump into the JavaScript component, I wanted to try it from my bash and realized it took a bit longer than I would have expected (graphql queries are oddly formatted). Since other people might want to do the same, added a slide where they can copy and paste the commands and a sample file where the query is properly formatted.

For people using Gitpod it will look something like this:

![image](https://user-images.githubusercontent.com/1128312/124240210-d12dbb80-db1a-11eb-8bf7-e3fd52790ffa.png)

Hope it helps :)